### PR TITLE
Adding docker.io as default docker host

### DIFF
--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 # defaults file for ansible-service-broker-setup
 dockerhub_org: feedhenry
+dockerhost: docker.io
 launch_apb_on_bind: true

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -11,9 +11,10 @@
     
   - name: Copy APB's from feedhenry docker org to {{ dockerhub_org }}
     shell: >
-      docker pull docker.io/feedhenry/{{ item.name }}:latest && 
-      docker tag docker.io/feedhenry/{{ item.name }}:latest {{dockerhub_org}}/{{ item.name }}:latest && 
-      docker push {{dockerhub_org}}/{{ item.name }}:latest
+      docker login -u {{dockerhub_username}} -p {{dockerhub_password}} {{dockerhost}} &&
+      docker pull docker.io/feedhenry/{{ item.name }}:latest &&
+      docker tag docker.io/feedhenry/{{ item.name }}:latest {{dockerhost}}/{{dockerhub_org}}/{{ item.name }}:latest &&
+      docker push {{dockerhost}}/{{dockerhub_org}}/{{ item.name }}:latest
     loop_control:
       label: "{{ item.name }}"
     with_items: 


### PR DESCRIPTION
Fedora the docker CLI is not defaulting to docker.io